### PR TITLE
fix successAction

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -308,13 +308,13 @@ async def lnurl_callback(
             {
                 "pr": payment_request,
                 "successAction": {
-                    "tag": "text",
-                    "description": f"{int(amount / 1000)}sats sent"
+                    "tag": "message",
+                    "message": f"{int(amount / 1000)} sats sent"
                 },
                 "routes": [],
             }
         )
-        
+
         return resp
 
     payment_hash, payment_request = await create_invoice(


### PR DESCRIPTION
With the previous code, I could not pay it using Wallet of Satoshi or Alby.

[LUD-09](https://github.com/lnurl/luds/blob/luds/09.md) defines `message` or `url`, but it was `text`. I guess they are validating it for some reason.

After the change, I was able to pay it.